### PR TITLE
Fix S1009 linter error: omit nil check for slice length

### DIFF
--- a/pkg/openapi2mcp/register.go
+++ b/pkg/openapi2mcp/register.go
@@ -872,7 +872,7 @@ func RegisterOpenAPITools(server *mcpserver.MCPServer, ops []OpenAPIOperation, d
 	baseURLs := []string{}
 	if os.Getenv("OPENAPI_BASE_URL") != "" {
 		baseURLs = append(baseURLs, os.Getenv("OPENAPI_BASE_URL"))
-	} else if doc.Servers != nil && len(doc.Servers) > 0 {
+	} else if len(doc.Servers) > 0 {
 		for _, s := range doc.Servers {
 			if s != nil && s.URL != "" {
 				baseURLs = append(baseURLs, s.URL)


### PR DESCRIPTION
## Summary
- Fixed S1009 staticcheck linter error in `pkg/openapi2mcp/register.go:875`
- Removed unnecessary nil check before `len()` call on `doc.Servers` slice
- The `len()` function for nil slices is defined as zero in Go, making the nil check redundant

## Test plan
- [x] Verified fix with `golangci-lint run ./...`
- [x] Confirmed no S1009 errors remain in codebase
- [x] Code builds and runs successfully

🤖 Generated with [Claude Code](https://claude.ai/code)